### PR TITLE
Do not transform object on coercion but just return value

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -574,6 +574,28 @@ suite('Coercion', function () {
     })
   })
 
+  test('Should allow coercion of objects returning only object value', function () {
+    const SomeObject = function () {
+      this.type = 'sometype'
+      this.value = 'xxx'
+    }
+
+    var coercion = [{
+      test: function (key, value) { return value.type === 'sometype' },
+      transform: function (value) { return value }
+    }]
+    var options = { coercion: coercion }
+    var object = new SomeObject()
+
+    assert.deepEqual(flatten({
+      group1: {
+        object: object
+      }
+    }, options), {
+      'group1.object': object
+    })
+  })
+
   test('Cascading coercion', function () {
     var coercion = [{
       test: function (key, value) { return key === 'prop1' },


### PR DESCRIPTION
Hi,

I want to flatten an object leaving objects like Mongo ObjectIDs as objects instead of transforming into string values. I added a (failing) test to illustrate the expected behavior.

Do you think this can be possible to achieve such behavior?

Best regards