### PR TITLE
Fix unflatten prototype pollution

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,6 +113,10 @@ function unflatten (target, opts) {
     var recipient = result
 
     while (key2 !== undefined) {
+      if (key1 === '__proto__') {
+        return
+      }
+
       var type = Object.prototype.toString.call(recipient[key1])
       var isobject = (
         type === '[object Object]' ||

--- a/test/test.js
+++ b/test/test.js
@@ -470,6 +470,20 @@ suite('Unflatten', function () {
       })
     })
   }
+
+  test('should not pollute prototype', function () {
+      unflatten({
+          '__proto__.polluted': true
+      });
+      unflatten({
+          'prefix.__proto__.polluted': true
+      });
+      unflatten({
+          'prefix.0.__proto__.polluted': true
+      });
+
+      assert.notStrictEqual({}.polluted, true);
+  })
 })
 
 suite('Arrays', function () {


### PR DESCRIPTION
The `unflatten` function contains a [prototype pollution](https://github.com/Kirill89/prototype-pollution-explained) vulnerability. I've added a test and fix.

This fixes #5 .